### PR TITLE
Fixed error handling in memcache sessions

### DIFF
--- a/session/memcache/sess_memcache.go
+++ b/session/memcache/sess_memcache.go
@@ -128,9 +128,12 @@ func (rp *MemProvider) SessionRead(sid string) (session.Store, error) {
 		}
 	}
 	item, err := client.Get(sid)
-	if err != nil && err == memcache.ErrCacheMiss {
-		rs := &SessionStore{sid: sid, values: make(map[interface{}]interface{}), maxlifetime: rp.maxlifetime}
-		return rs, nil
+	if err != nil {
+		if err == memcache.ErrCacheMiss {
+			rs := &SessionStore{sid: sid, values: make(map[interface{}]interface{}), maxlifetime: rp.maxlifetime}
+			return rs, nil
+		}
+		return nil, err
 	}
 	var kv map[interface{}]interface{}
 	if len(item.Value) == 0 {


### PR DESCRIPTION
Currently if provided an invalid endpoint memcache it will error on a nil pointer later because the first error with the data is being ignored.